### PR TITLE
Change gender ratio controls to minimum threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,19 +39,19 @@
                 <legend>Set Gender Ratios</legend>
                 <div id="female_slider">
                     <label for="female_ratio_input">Female</label>
-                    <input id="female_ratio_input" type="range" min="0" max="100" value="70" class="slider"
+                    <input id="female_ratio_input" type="range" min="0" max="100" value="0" class="slider"
                            oninput="female_ratio_output.value = female_ratio_input.value + '%'">
                     <output id="female_ratio_output">70%</output>
                 </div>
                 <div id="male_slider">
                     <label for="male_ratio_input">Male</label>
-                    <input id="male_ratio_input" type="range" min="0" max="100" value="70" class="slider"
+                    <input id="male_ratio_input" type="range" min="0" max="100" value="0" class="slider"
                            oninput="male_ratio_output.value = male_ratio_input.value + '%'">
                     <output id="male_ratio_output">70%</output>
                 </div>
-                <p>These sliders set the maximum percentage of male or female students allowed in any given
-                    section/class. Setting the slider to 70% for female students would mean that any section should
-                    be composed of at most 70% female students.</p>
+                <p>These sliders set the minimum percentage of male or female students allowed in any given
+                    section/class. Setting both sliders to 0% means that gender should not be a consideration for course
+                    allocations.</p>
             </fieldset>
         </li>
         <li id="athlete_container">

--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@
                     <label for="female_ratio_input">Female</label>
                     <input id="female_ratio_input" type="range" min="0" max="100" value="0" class="slider"
                            oninput="female_ratio_output.value = female_ratio_input.value + '%'">
-                    <output id="female_ratio_output">70%</output>
+                    <output id="female_ratio_output">0%</output>
                 </div>
                 <div id="male_slider">
                     <label for="male_ratio_input">Male</label>
                     <input id="male_ratio_input" type="range" min="0" max="100" value="0" class="slider"
                            oninput="male_ratio_output.value = male_ratio_input.value + '%'">
-                    <output id="male_ratio_output">70%</output>
+                    <output id="male_ratio_output">0%</output>
                 </div>
                 <p>These sliders set the minimum percentage of male or female students allowed in any given
                     section/class. Setting both sliders to 0% means that gender should not be a consideration for course

--- a/index.js
+++ b/index.js
@@ -100,11 +100,7 @@ window.onload = function () {
     /** Toggles the state of the 'run' button based on the states of studentsHandled and sectionsHandled. */
     function handleRunButton() {
         document.getElementById("save_as").disabled = true;
-        if (studentsHandled && sectionsHandled) {
-            document.getElementById("run").disabled = false;
-        } else {
-            document.getElementById("run").disabled = true;
-        }
+        document.getElementById("run").disabled = !(studentsHandled && sectionsHandled);
     }
 
 
@@ -133,6 +129,7 @@ window.onload = function () {
 
         // TODO: Generate a report of the gender/athlete balances, smallest classes, most popular class choice, etc.
         let report = createReport();
+        printReport(report);
 
         document.getElementById("run").disabled = false;
         document.getElementById("save_as").disabled = false;
@@ -182,7 +179,7 @@ window.onload = function () {
             let numSeats = currentSection["Student Cap"];
 
             // Reserve a number of seats for males:
-            let numMaleSeats = Math.round(numSeats * (1 - getMaleRatioInput()));
+            let numMaleSeats = Math.round(numSeats * getMaleRatioInput());
             for (let i = 0; i < numMaleSeats; i++) {
                 seatsArray.push({
                     reserved: true,
@@ -192,7 +189,7 @@ window.onload = function () {
             }
 
             // Reserve a number of seats for females
-            let numFemaleSeats = Math.round(numSeats * (1 - getFemaleRatioInput()));
+            let numFemaleSeats = Math.round(numSeats * getFemaleRatioInput());
             for (let i = 0; i < numFemaleSeats; i++) {
                 seatsArray.push({
                     reserved: true,


### PR DESCRIPTION
Previously, the gender ratio sliders set the maximum threshold for each gender in any section. The code accounts for this by reserving [(1 - other  gender ratio) * #seats] number of seats for each gender in the class (I.e. if the maximum female ratio is 70%, then reserve 30% of the seats for male students).

**_Now_** the sliders represent the minimum threshold for each gender in any section and the code accounts for this by reserving (ratio * #seats) number of seats for that gender in the class. (I.e. _if the minimum female ratio is 30%, then reserve 30% of the seats for female students_).